### PR TITLE
Visualize child commits that are part of a merge commit

### DIFF
--- a/bin/git-bc-show-eligible
+++ b/bin/git-bc-show-eligible
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# coding=utf-8
+
+from __future__ import unicode_literals
 
 import subprocess
 import argparse
@@ -96,10 +99,37 @@ if sys.stdout.isatty():
     author_format_str = ' \033[31m| %s <%s>\033[0m'
     commit_format_str = '\033[33m%s\033[0m %s%s'
 
+seen = ''
+groups = []
+current_group = []
 for commit in find_unpicked(repo, from_commit, to_commit, since_commit, args.all):
     author_info = ''
     if args.all:
         author_info = author_format_str % (commit.author.name, commit.author.email)
 
-    print(commit_format_str % (str(commit.id), commit.message[:commit.message.index('\n')],
-                               author_info))
+    commit_msg = commit.message[:commit.message.index('\n')]
+    indent = commit_msg in seen
+    seen += commit.message
+
+    commit_string = (commit_format_str % (str(commit.id), commit_msg, author_info))
+
+    if indent:
+        current_group.append(commit_string)
+    else:
+        if current_group:
+            groups.append(current_group)
+        current_group = [commit_string]
+
+for group in groups:
+    merge = group[0]
+    child_commits = group[1:-1]
+    last_child_commit = group[-1] if len(group) > 1 else ''
+
+    print(merge)
+
+    for child in child_commits:
+       print(" ├─ {}".format(child))
+
+    if last_child_commit:
+       print(" └─ {}".format(last_child_commit))
+


### PR DESCRIPTION
Thanks Luca for eXtreme Programming this one with me :)

Before:

```
29a6a2f5acb5a96693ca8cdf24fdc8651bd62ff4 add edge heate template and edge setup sites.yaml for krusty automated deployment | Johnny Devaprasad <johnny.devaprasad@brightcomputing.com>
985dae4f5dd1a7fb47fa976f09b5be8e2c35fa50 Merge pull request #1566 in CM/cluster-tools from Ceph_dashboard_Prometheus_reiterate_removal to master | Luca Castoro <luca.castoro@brightcomputing.com>
5550b9decae3389eafd8b6c68f080a41ac37298c Fixed a couple of PEP8 violations. | Luca Castoro <luca.castoro@brightcomputing.com>
843eb231a763056ebb79fb3549b95864fd7fa582 Support reissuing the uninstallation phase multiple times. | Luca Castoro <luca.castoro@brightcomputing.com>
1b051da571485d6b354a5047cdda771ab79642fb Merge pull request #1567 in CM/cluster-tools from ~MOHAMEDA/cluster-tools:fix-style-issue to master | Mohamed Abidi <mohamed.abidi@brightcomputing.com>
11105d4ffcfb38307231ee19391cf3feeea7c772 Merge pull request #1558 in CM/cluster-tools from ~MOHAMEDA/cluster-tools:CM-21777-add-external-internal-and-virtual-networking-to-site to master | Mohamed Abidi <mohamed.abidi@brightcomputing.com>
f55abb752ee5c8169f1c84d45098b86e950bf294 Merge pull request #1557 in CM/cluster-tools from pythoncm2_examples to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
637285a2105b74cdc27f24e4ebb90bb98ea79ad8 Merge pull request #1554 in CM/cluster-tools from utf8_pythoncm2 to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
03c2118eb168035e3dc50b5c09ad79662a077ada Merge pull request #1551 in CM/cluster-tools from CM-21364-CephDashboard to master | Luca Castoro <luca.castoro@brightcomputing.com>
977829622df435a97925a04cd5e14664276173a4 Minor improvements based on the Team feedbacks. | Luca Castoro <luca.castoro@brightcomputing.com>
fb5025e52041512d17718d375df17c8e7d96b16c CM-21364 - Enable access to the Ceph Dashboard from the BrightView landing page. | Luca Castoro <luca.castoro@brightcomputing.com>
fd7db6bb575917e91c83f52b9b32dbc533695920 Merge pull request #1552 in CM/cluster-tools from cm-digits-setup to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
54b4dba4ffe77b539ac233e978e2853e940463fc Merge pull request #1549 in CM/cluster-tools from cm-jupyterhub-setup to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
d4e1c06261092b7a1fa36ba5dd07c163a87605a3 Merge pull request #1499 in CM/cluster-tools from ceph to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
0a8ef13974826e591f71370615f3519f89105d79 Merge pull request #1545 in CM/cluster-tools from beegfs to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
13fac19b2e1a4254d458f88b38c129bdbcf4b103 Merge pull request #1543 in CM/cluster-tools from docker_registry to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
3bb0d3b960ddf16fe4143eae0810bf524733ccbc Merge pull request #1536 in CM/cluster-tools from pythoncm2_shared to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
```


after:

```
29a6a2f5acb5a96693ca8cdf24fdc8651bd62ff4 add edge heate template and edge setup sites.yaml for krusty automated deployment | Johnny Devaprasad <johnny.devaprasad@brightcomputing.com>
985dae4f5dd1a7fb47fa976f09b5be8e2c35fa50 Merge pull request #1566 in CM/cluster-tools from Ceph_dashboard_Prometheus_reiterate_removal to master | Luca Castoro <luca.castoro@brightcomputing.com>
 ├─ 5550b9decae3389eafd8b6c68f080a41ac37298c Fixed a couple of PEP8 violations. | Luca Castoro <luca.castoro@brightcomputing.com>
 └─ 843eb231a763056ebb79fb3549b95864fd7fa582 Support reissuing the uninstallation phase multiple times. | Luca Castoro <luca.castoro@brightcomputing.com>
1b051da571485d6b354a5047cdda771ab79642fb Merge pull request #1567 in CM/cluster-tools from ~MOHAMEDA/cluster-tools:fix-style-issue to master | Mohamed Abidi <mohamed.abidi@brightcomputing.com>
11105d4ffcfb38307231ee19391cf3feeea7c772 Merge pull request #1558 in CM/cluster-tools from ~MOHAMEDA/cluster-tools:CM-21777-add-external-internal-and-virtual-networking-to-site to master | Mohamed Abidi <mohamed.abidi@brightcomputing.com>
f55abb752ee5c8169f1c84d45098b86e950bf294 Merge pull request #1557 in CM/cluster-tools from pythoncm2_examples to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
637285a2105b74cdc27f24e4ebb90bb98ea79ad8 Merge pull request #1554 in CM/cluster-tools from utf8_pythoncm2 to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
03c2118eb168035e3dc50b5c09ad79662a077ada Merge pull request #1551 in CM/cluster-tools from CM-21364-CephDashboard to master | Luca Castoro <luca.castoro@brightcomputing.com>
 ├─ 977829622df435a97925a04cd5e14664276173a4 Minor improvements based on the Team feedbacks. | Luca Castoro <luca.castoro@brightcomputing.com>
 └─ fb5025e52041512d17718d375df17c8e7d96b16c CM-21364 - Enable access to the Ceph Dashboard from the BrightView landing page. | Luca Castoro <luca.castoro@brightcomputing.com>
fd7db6bb575917e91c83f52b9b32dbc533695920 Merge pull request #1552 in CM/cluster-tools from cm-digits-setup to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
54b4dba4ffe77b539ac233e978e2853e940463fc Merge pull request #1549 in CM/cluster-tools from cm-jupyterhub-setup to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
d4e1c06261092b7a1fa36ba5dd07c163a87605a3 Merge pull request #1499 in CM/cluster-tools from ceph to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
0a8ef13974826e591f71370615f3519f89105d79 Merge pull request #1545 in CM/cluster-tools from beegfs to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
13fac19b2e1a4254d458f88b38c129bdbcf4b103 Merge pull request #1543 in CM/cluster-tools from docker_registry to master | Aleksei Stepanov <aleksei.stepanov@brightcomputing.com>
```

