### PR TITLE
Enforce python3 as interpreter for bc-show-eligible

### DIFF
--- a/bin/git-bc-show-eligible
+++ b/bin/git-bc-show-eligible
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 
 from __future__ import unicode_literals


### PR DESCRIPTION
Upon installing this in a new system, I was having issues to load some
modules (namely pygit2), and this was due to the fact that I only had
those installed for python3, and unfortunatelly my system default
interpreter is still the should-be-dead python2.

Making this change in my local installation fixed the issue for me.