### PR TITLE
BCM-35734: GIT-HELPERS: Add pytest test suite for bc-show-eligible and bc-cherry-pick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea
 *.swp
+__pycache__
+tests/fixtures/*.fi
+tests/.pytest_cache/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,91 @@
+import subprocess
+import pytest
+from pathlib import Path
+
+FIXTURES_DIR = Path(__file__).parent / 'fixtures'
+BIN_DIR = Path(__file__).parent.parent / 'bin'
+
+
+def cmd_info(result):
+    """Format a CompletedProcess into a readable diagnostic block for assertion messages."""
+    cmd = ' '.join(str(a) for a in result.args)
+    return '\n'.join([
+        f'$ {cmd}',
+        f'exit: {result.returncode}',
+        f'stdout:\n{result.stdout.rstrip()}',
+        f'stderr:\n{result.stderr.rstrip()}',
+    ])
+
+
+def git(repo_dir, *args, check=True):
+    return subprocess.run(
+        ['git', *args],
+        cwd=repo_dir,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def resolve_ref(repo_dir, ref):
+    return git(repo_dir, 'rev-parse', ref).stdout.strip()
+
+
+@pytest.fixture
+def make_repo(tmp_path):
+    """Return a factory that creates a git repo from a .fi fixture file."""
+    def _make(fixture_name):
+        repo_dir = tmp_path / fixture_name
+        repo_dir.mkdir()
+        git(repo_dir, 'init')
+        git(repo_dir, 'config', 'user.email', 'test@test')
+        git(repo_dir, 'config', 'user.name', 'Test')
+        fi_path = FIXTURES_DIR / f'{fixture_name}.fi'
+        with fi_path.open('rb') as f:
+            subprocess.run(
+                ['git', 'fast-import', '--quiet'],
+                cwd=repo_dir, stdin=f, check=True, capture_output=True,
+            )
+        git(repo_dir, 'checkout', 'master')
+        return repo_dir
+    return _make
+
+
+def git_cherry_pick(repo_dir, ref, branch):
+    """Cherry-pick ref onto branch with -x annotation."""
+    commit_hash = resolve_ref(repo_dir, ref)
+    git(repo_dir, 'checkout', branch)
+    git(repo_dir, 'cherry-pick', '-x', '--allow-empty', commit_hash)
+    git(repo_dir, 'checkout', 'master')
+
+
+def git_cherry_pick_merge(repo_dir, ref, mainline, branch):
+    """Cherry-pick a merge commit onto branch, specifying the mainline parent index (1-based)."""
+    commit_hash = resolve_ref(repo_dir, ref)
+    git(repo_dir, 'checkout', branch)
+    git(repo_dir, 'cherry-pick', '-m', str(mainline), '-x', '--allow-empty', commit_hash)
+    git(repo_dir, 'checkout', 'master')
+
+
+def bc_cherry_pick(repo_dir, commit_ref, *args):
+    """Run git-bc-cherry-pick on commit_ref from the repo's current branch."""
+    commit_hash = resolve_ref(repo_dir, commit_ref)
+    result = subprocess.run(
+        [BIN_DIR / 'git-bc-cherry-pick', *args, commit_hash],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+    )
+    print(cmd_info(result))
+    return result
+
+
+def bc_show_eligible(repo_dir, *args):
+    result = subprocess.run(
+        [BIN_DIR / 'git-bc-show-eligible', *args],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+    )
+    print(cmd_info(result))
+    return result

--- a/tests/fixtures/bc_cherry_pick_scenarios.sh
+++ b/tests/fixtures/bc_cherry_pick_scenarios.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Builds the bc_cherry_pick_scenarios fixture repo and exports it as a
+# fast-import stream to bc_cherry_pick_scenarios.fi.
+#
+# Re-run this script whenever you need to update the fixture topology.
+#
+# master:   A(init) --- X(master.txt) --- M --- P(patch.txt)
+#                                        /
+# feature1: (A): F1(feat1.txt) --- F2(feat2.txt)
+#
+# stable:   A(init) --- S1(stable.txt)
+#
+# All commits add a unique file so cherry-picks never conflict.
+# M: parents[0]=X (mainline), parents[1]=F2 (feature tip)
+# P: standalone commit after the merge (for regular cherry-pick tests)
+
+set -e
+
+REPO=$(mktemp -d)
+trap "rm -rf $REPO" EXIT
+
+git -C $REPO init -q
+git -C $REPO config user.email test@test
+git -C $REPO config user.name Test
+
+# A - initial commit
+echo "init" > $REPO/init.txt
+git -C $REPO add init.txt
+git -C $REPO commit -m "Initial commit" -q
+
+# stable branches off at A
+git -C $REPO checkout -b stable -q
+echo "stable fix" > $REPO/stable.txt
+git -C $REPO add stable.txt
+git -C $REPO commit -m "STABLE: stable fix" -q
+git -C $REPO checkout master -q
+
+# X - a commit on master only
+echo "master change" > $REPO/master.txt
+git -C $REPO add master.txt
+git -C $REPO commit -m "XXX-1: Master commit" -q
+
+# feature1 from A
+git -C $REPO checkout -b feature1 "$(git -C $REPO rev-parse master~1)" -q
+echo "feature 1" > $REPO/feat1.txt
+git -C $REPO add feat1.txt
+git -C $REPO commit -m "XXX-2: Feature part 1" -q
+echo "feature 2" > $REPO/feat2.txt
+git -C $REPO add feat2.txt
+git -C $REPO commit -m "XXX-2: Feature part 2" -q
+
+# M - master merges feature1 (parents[0]=X, parents[1]=F2)
+git -C $REPO checkout master -q
+git -C $REPO merge --no-ff feature1 -m "XXX-2: Feature done" -q
+
+# P - standalone commit after the merge
+echo "patch" > $REPO/patch.txt
+git -C $REPO add patch.txt
+git -C $REPO commit -m "XXX-3: Patch" -q
+
+git -C $REPO fast-export --all > "$(dirname "$0")/bc_cherry_pick_scenarios.fi"
+echo "Written bc_cherry_pick_scenarios.fi"

--- a/tests/fixtures/mainline_not_first_parent.sh
+++ b/tests/fixtures/mainline_not_first_parent.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Builds the mainline_not_first_parent fixture repo and exports it as a
+# fast-import stream to mainline_not_first_parent.fi.
+#
+# Re-run this script whenever you need to update the fixture topology.
+#
+# master:   A --- X ----------- M_outer
+#                  \           /
+# feature: (A): F1--M_inner---F2
+#
+# stable:   A
+#
+# M_inner: parents[0]=F1, parents[1]=X (mainline)
+# Feature did `git merge master` at X, so X ends up at parents[1] of M_inner.
+# After M_outer is cherry-picked to stable, M_inner becomes a top-level
+# eligible commit and show-eligible must print --select=X_hash before it.
+
+set -e
+
+REPO=$(mktemp -d)
+trap "rm -rf $REPO" EXIT
+
+git -C $REPO init -q
+git -C $REPO config user.email test@test
+git -C $REPO config user.name Test
+
+# A - initial commit (common ancestor of master and stable)
+git -C $REPO commit --allow-empty -m "Initial commit" -q
+
+# stable branches off here (empty - tests will cherry-pick M_outer onto it)
+git -C $REPO checkout -b stable -q
+git -C $REPO checkout master -q
+
+# X - a commit on master only (will become parents[1] of M_inner)
+git -C $REPO commit --allow-empty -m "XXX-1: Master commit" -q
+
+# feature from A (one commit before X)
+git -C $REPO checkout -b feature "$(git -C $REPO rev-parse master~1)" -q
+
+# F1
+git -C $REPO commit --allow-empty -m "XXX-2: Feature part 1" -q
+
+# M_inner: feature syncs with master — parents[0]=F1 (feature), parents[1]=X (mainline)
+git -C $REPO merge --no-ff master -m "XXX-2: Sync with master" -q
+
+# F2
+git -C $REPO commit --allow-empty -m "XXX-2: Feature part 2" -q
+
+# M_outer: master merges feature — parents[0]=X (mainline), parents[1]=F2
+git -C $REPO checkout master -q
+git -C $REPO merge --no-ff feature -m "XXX-2: Feature done" -q
+
+git -C $REPO fast-export --all > "$(dirname "$0")/mainline_not_first_parent.fi"
+echo "Written mainline_not_first_parent.fi"

--- a/tests/fixtures/merge_differing_messages.sh
+++ b/tests/fixtures/merge_differing_messages.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Builds the merge_differing_messages fixture repo and exports it as a
+# fast-import stream to merge_differing_messages.fi.
+#
+# Re-run this script whenever you need to update the fixture topology.
+#
+# master:   A --- M1 ----------- M2 --- P --- M3
+#               /               /             /
+# feature1: B-C+                |             |
+# feature2:          D --- E ---+             |
+# feature3:                          F - G - H+
+#
+# stable:   A --- S1 --- S2
+#
+# M1: feature1 messages match merge message (normal grouping case)
+# M2: feature2 messages DIFFER from merge message (the original bug)
+# P:  standalone commit (cherry-picked to stable in tests)
+# M3: feature3, three commits deep
+
+set -e
+
+REPO=$(mktemp -d)
+trap "rm -rf $REPO" EXIT
+
+git -C $REPO init -q
+git -C $REPO config user.email test@test
+git -C $REPO config user.name Test
+
+# A - initial commit (common ancestor of master and stable)
+git -C $REPO commit --allow-empty -m "Initial commit" -q
+
+# stable branches off here
+git -C $REPO checkout -b stable -q
+git -C $REPO commit --allow-empty -m "STABLE: Backport fix 1" -q
+git -C $REPO commit --allow-empty -m "STABLE: Backport fix 2" -q
+
+# feature1 - messages match merge
+git -C $REPO checkout master -q
+git -C $REPO checkout -b feature1 -q
+git -C $REPO commit --allow-empty -m "XXX-10: Add widget A" -q
+git -C $REPO commit --allow-empty -m "XXX-10: Add widget B" -q
+
+# M1 - merge of feature1, message matches last child
+git -C $REPO checkout master -q
+git -C $REPO merge --no-ff feature1 -m "XXX-10: Add widget B" -q
+
+# feature2 - messages DIFFER from merge (the original bug)
+git -C $REPO checkout -b feature2 -q
+git -C $REPO commit --allow-empty -m "XXX-20: Refactor part 1" -q
+git -C $REPO commit --allow-empty -m "XXX-20: Refactor part 2" -q
+
+# M2 - merge of feature2, message intentionally differs from children
+git -C $REPO checkout master -q
+git -C $REPO merge --no-ff feature2 -m "XXX-20: Refactor completed" -q
+
+# P - standalone commit (conftest will cherry-pick this to stable in tests)
+git -C $REPO commit --allow-empty -m "XXX-30: Fix nasty bug" -q
+
+# feature3 - three commits deep
+git -C $REPO checkout -b feature3 -q
+git -C $REPO commit --allow-empty -m "XXX-40: New API v1" -q
+git -C $REPO commit --allow-empty -m "XXX-40: New API v2" -q
+git -C $REPO commit --allow-empty -m "XXX-40: New API v3" -q
+
+# M3 - merge of feature3
+git -C $REPO checkout master -q
+git -C $REPO merge --no-ff feature3 -m "XXX-40: New API v3" -q
+
+git -C $REPO fast-export --all > "$(dirname "$0")/merge_differing_messages.fi"
+echo "Written merge_differing_messages.fi"

--- a/tests/fixtures/octopus_merge.sh
+++ b/tests/fixtures/octopus_merge.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Builds the octopus_merge fixture repo and exports it as a
+# fast-import stream to octopus_merge.fi.
+#
+# Re-run this script whenever you need to update the fixture topology.
+#
+# master:   A(init) --- X(x.txt) --- M_oct
+#                                   /    \
+# feature1: (A): F1(f1.txt)--F2(f2.txt)  |
+# feature2: (A): G1(g1.txt)--------------+
+#
+# stable:   A(init) --- S1(stable.txt)
+#
+# M_oct: parents[0]=X (mainline), parents[1]=F2, parents[2]=G1
+# All commits add a unique file so cherry-picks never conflict.
+
+set -e
+
+REPO=$(mktemp -d)
+trap "rm -rf $REPO" EXIT
+
+git -C $REPO init -q
+git -C $REPO config user.email test@test
+git -C $REPO config user.name Test
+
+# A - initial commit
+echo "init" > $REPO/init.txt
+git -C $REPO add init.txt
+git -C $REPO commit -m "Initial commit" -q
+
+# stable branches off at A
+git -C $REPO checkout -b stable -q
+echo "stable" > $REPO/stable.txt
+git -C $REPO add stable.txt
+git -C $REPO commit -m "STABLE: stable fix" -q
+git -C $REPO checkout master -q
+
+# X - a commit on master only
+echo "x" > $REPO/x.txt
+git -C $REPO add x.txt
+git -C $REPO commit -m "XXX-1: Master commit" -q
+
+# feature1 from A
+git -C $REPO checkout -b feature1 "$(git -C $REPO rev-parse master~1)" -q
+echo "f1" > $REPO/f1.txt
+git -C $REPO add f1.txt
+git -C $REPO commit -m "XXX-2: Feature1 part 1" -q
+echo "f2" > $REPO/f2.txt
+git -C $REPO add f2.txt
+git -C $REPO commit -m "XXX-2: Feature1 part 2" -q
+
+# feature2 from A
+git -C $REPO checkout -b feature2 "$(git -C $REPO rev-parse master~1)" -q
+echo "g1" > $REPO/g1.txt
+git -C $REPO add g1.txt
+git -C $REPO commit -m "XXX-3: Feature2 commit" -q
+
+# M_oct - octopus merge on master (parents[0]=X, parents[1]=F2, parents[2]=G1)
+git -C $REPO checkout master -q
+git -C $REPO merge --no-ff feature1 feature2 -m "XXX-2/3: Merge feature1 and feature2" -q
+
+git -C $REPO fast-export --all > "$(dirname "$0")/octopus_merge.fi"
+echo "Written octopus_merge.fi"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Build all fixture repos and run the test suite.
+# Usage: tests/run_tests.sh [pytest options...]
+set -e
+cd "$(dirname "$0")"
+
+for script in fixtures/*.sh; do
+    echo "Building fixture: $script"
+    bash "$script"
+done
+
+exec python3 -m pytest . "$@"

--- a/tests/test_cherry_pick.py
+++ b/tests/test_cherry_pick.py
@@ -1,0 +1,127 @@
+from conftest import bc_cherry_pick, resolve_ref, git
+
+
+def last_commit_message(repo_dir, branch='stable'):
+    return git(repo_dir, 'log', '-n', '1', '--format=%B', branch).stdout.strip()
+
+
+def test_regular_commit_cherry_pick(make_repo):
+    """A plain commit is cherry-picked as-is with no children annotation."""
+    repo = make_repo('bc_cherry_pick_scenarios')
+    git(repo, 'checkout', 'stable')
+    result = bc_cherry_pick(repo, 'master', 'master')  # P is master tip
+    git(repo, 'checkout', 'master')
+
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+    msg = last_commit_message(repo)
+    assert 'XXX-3: Patch' in msg, f"commit message:\n{msg}"
+    assert '(with child' not in msg, f"unexpected children annotation in:\n{msg}"
+
+
+def test_merge_commit_appends_children(make_repo):
+    """Cherry-picking a merge commit appends (with child HASH) lines for each branch child."""
+    repo = make_repo('bc_cherry_pick_scenarios')
+    # M = master~1; parents[0]=X, parents[1]=F2; F1 is F2's first parent
+    f2_hash = resolve_ref(repo, 'master~1^2')    # F2: M's branch parent (parents[1])
+    f1_hash = resolve_ref(repo, 'master~1^2^1')  # F1: F2's first parent
+
+    git(repo, 'checkout', 'stable')
+    result = bc_cherry_pick(repo, 'master~1', 'master~1')
+    git(repo, 'checkout', 'master')
+
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+    msg = last_commit_message(repo)
+    assert f'(with child {f2_hash})' in msg, \
+        f"expected '(with child {f2_hash[:8]}...)' in commit message:\n{msg}"
+    assert f'(with child {f1_hash})' in msg, \
+        f"expected '(with child {f1_hash[:8]}...)' in commit message:\n{msg}"
+
+
+def test_select_overrides_mainline(make_repo):
+    """--select makes the specified parent the mainline, changing which side is applied."""
+    repo = make_repo('bc_cherry_pick_scenarios')
+    # M = master~1, parents[0]=X (mainline by default), parents[1]=F2 (feature)
+    # With --select=F2, mainline becomes F2 and we apply the X side (master.txt)
+    f2_hash = resolve_ref(repo, 'master~1^2')
+    x_hash = resolve_ref(repo, 'master~1^1')
+
+    git(repo, 'checkout', 'stable')
+    result = bc_cherry_pick(repo, 'master~1', 'master~1', f'--select={f2_hash}')
+    git(repo, 'checkout', 'master')
+
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+    msg = last_commit_message(repo)
+    assert f'(with child {x_hash})' in msg, \
+        f"expected '(with child {x_hash[:8]}...)' in commit message:\n{msg}"
+    stable_files = git(repo, 'ls-tree', '-r', '--name-only', 'stable').stdout.split()
+    assert 'master.txt' in stable_files, f"master.txt missing from stable tree: {stable_files}"
+    assert 'feat1.txt' not in stable_files, f"feat1.txt should not be in stable tree: {stable_files}"
+    assert 'feat2.txt' not in stable_files, f"feat2.txt should not be in stable tree: {stable_files}"
+
+
+def test_no_commit_writes_to_merge_msg(make_repo):
+    """--no-commit stages changes and writes the children list to MERGE_MSG without committing."""
+    repo = make_repo('bc_cherry_pick_scenarios')
+    head_before = resolve_ref(repo, 'stable')
+
+    git(repo, 'checkout', 'stable')
+    result = bc_cherry_pick(repo, 'master~1', 'master~1', '--no-commit')
+
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+    head_after = resolve_ref(repo, 'stable')
+    assert head_after == head_before, \
+        f"stable moved unexpectedly: {head_before[:8]} -> {head_after[:8]}"
+    merge_msg = (repo / '.git' / 'MERGE_MSG').read_text()
+    assert '(with child' in merge_msg, f"MERGE_MSG missing children annotation:\n{merge_msg}"
+
+    git(repo, 'reset', '--hard')
+    git(repo, 'checkout', 'master')
+
+
+def test_dry_run_prints_commands(make_repo):
+    """--dry-run prints the cherry-pick and amend commands without executing them."""
+    repo = make_repo('bc_cherry_pick_scenarios')
+    head_before = resolve_ref(repo, 'stable')
+
+    git(repo, 'checkout', 'stable')
+    result = bc_cherry_pick(repo, 'master~1', 'master~1', '--dry-run')
+    git(repo, 'checkout', 'master')
+
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+    assert 'git cherry-pick' in result.stdout
+    assert 'git commit --amend' in result.stdout
+    head_after = resolve_ref(repo, 'stable')
+    assert head_after == head_before, \
+        f"stable moved despite --dry-run: {head_before[:8]} -> {head_after[:8]}"
+
+
+def test_select_unknown_hash_fails(make_repo):
+    """--select with a hash that doesn't match any parent exits with an error."""
+    repo = make_repo('bc_cherry_pick_scenarios')
+
+    git(repo, 'checkout', 'stable')
+    result = bc_cherry_pick(repo, 'master~1', 'master~1', '--select=deadbeef')
+    git(repo, 'checkout', 'master')
+
+    assert result.returncode != 0, "expected non-zero exit for unknown --select"
+    assert 'Error' in result.stdout or 'Error' in result.stderr
+
+
+def test_octopus_merge_cherry_pick(make_repo):
+    """Cherry-picking an octopus merge succeeds; children from the first branch parent are annotated."""
+    repo = make_repo('octopus_merge')
+    # M_oct = master tip; parents[0]=X (mainline), parents[1]=F2, parents[2]=G1
+    f2_hash = resolve_ref(repo, 'master^2')   # F2: first branch parent
+    f1_hash = resolve_ref(repo, 'master^2^1') # F1: F2's parent
+
+    git(repo, 'checkout', 'stable')
+    result = bc_cherry_pick(repo, 'master', 'master')
+    git(repo, 'checkout', 'master')
+
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+    msg = last_commit_message(repo)
+    # Children from parents[1] (feature1) must be annotated
+    assert f'(with child {f2_hash})' in msg, \
+        f"expected '(with child {f2_hash[:8]}...)' in commit message:\n{msg}"
+    assert f'(with child {f1_hash})' in msg, \
+        f"expected '(with child {f1_hash[:8]}...)' in commit message:\n{msg}"

--- a/tests/test_show_eligible.py
+++ b/tests/test_show_eligible.py
@@ -1,0 +1,101 @@
+from conftest import bc_show_eligible, git_cherry_pick, git_cherry_pick_merge, resolve_ref
+
+
+def test_merge_groups_by_parentage(make_repo):
+    """Merge commits are grouped with their children regardless of message similarity."""
+    repo = make_repo('merge_differing_messages')
+    result = bc_show_eligible(repo, 'master', 'stable')
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+    lines = result.stdout.splitlines()
+
+    # M1 and its two children must appear as a group (messages match)
+    m1_idx = next((i for i, l in enumerate(lines) if 'XXX-10: Add widget B' in l and not l.startswith(' ')), None)
+    assert m1_idx is not None, "M1 (XXX-10: Add widget B) not found as top-level entry"
+    children = lines[m1_idx + 1:m1_idx + 3]
+    assert all(l.startswith(' ') for l in children), \
+        f"M1 children must be indented, got: {children}"
+    assert any('XXX-10: Add widget A' in l for l in children), \
+        f"XXX-10: Add widget A not grouped under M1, got: {children}"
+    assert any('XXX-10: Add widget B' in l for l in children), \
+        f"expected child also containing 'Add widget B', got: {children}"
+
+    # M2 and its children must be grouped even though messages differ
+    m2_idx = next((i for i, l in enumerate(lines) if 'XXX-20: Refactor completed' in l), None)
+    assert m2_idx is not None, "M2 (XXX-20: Refactor completed) not found in output"
+    children = lines[m2_idx + 1:m2_idx + 3]
+    assert all(l.startswith(' ') for l in children), \
+        f"M2 children must be indented, got: {children}"
+    assert any('XXX-20: Refactor part 1' in l for l in children), \
+        f"XXX-20: Refactor part 1 not grouped under M2, got: {children}"
+    assert any('XXX-20: Refactor part 2' in l for l in children), \
+        f"XXX-20: Refactor part 2 not grouped under M2, got: {children}"
+
+    # M3 and its three children must be grouped
+    m3_idx = next((i for i, l in enumerate(lines) if 'XXX-40: New API v3' in l and not l.startswith(' ')), None)
+    assert m3_idx is not None, "M3 (XXX-40: New API v3) not found as top-level entry"
+    children = lines[m3_idx + 1:m3_idx + 4]
+    assert all(l.startswith(' ') for l in children), \
+        f"M3 children must be indented, got: {children}"
+    assert len(children) == 3 and all('XXX-40' in l for l in children), \
+        f"expected 3 indented children all containing XXX-40, got: {children}"
+
+
+def test_cherry_picked_commit_excluded(make_repo):
+    """A commit already cherry-picked to the target branch does not appear as eligible."""
+    repo = make_repo('merge_differing_messages')
+    git_cherry_pick(repo, 'master~1', 'stable')  # cherry-pick P onto stable
+    result = bc_show_eligible(repo, 'master', 'stable')
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+    assert 'XXX-30: Fix nasty bug' not in result.stdout, \
+        "cherry-picked commit still appears as eligible"
+
+
+def test_mainline_not_first_parent(make_repo):
+    """When mainline is parents[1] of a sync merge, --select=HASH prefix is shown."""
+    repo = make_repo('mainline_not_first_parent')
+    # M_outer (master tip) was already handled; cherry-pick it to stable to exclude it
+    git_cherry_pick_merge(repo, 'master', 1, 'stable')
+
+    x_hash = resolve_ref(repo, 'master^1')  # M_outer's first parent is X (the mainline commit)
+    result = bc_show_eligible(repo, 'master', 'stable')
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+
+    lines = result.stdout.splitlines()
+    sync_line = next((l for l in lines if 'Sync with master' in l), None)
+    assert sync_line is not None, "'Sync with master' not found in output"
+    assert sync_line.startswith(f'--select={x_hash[:12]}'), \
+        f"expected line to start with '--select={x_hash[:12]}', got: {sync_line!r}"
+    sync_idx = lines.index(sync_line)
+    child_lines = lines[sync_idx + 1:sync_idx + 3]
+    assert any('Feature part 1' in l for l in child_lines), \
+        f"'Feature part 1' not grouped under sync commit, next lines: {child_lines}"
+
+
+def test_standalone_commit_visible(make_repo):
+    """A standalone commit not yet picked appears as a top-level entry."""
+    repo = make_repo('merge_differing_messages')
+    result = bc_show_eligible(repo, 'master', 'stable')
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+    top_level = [l for l in result.stdout.splitlines() if not l.startswith(' ')]
+    assert any('XXX-30: Fix nasty bug' in l for l in top_level), \
+        "'XXX-30: Fix nasty bug' not found as a top-level entry"
+
+
+def test_octopus_merge_children_grouped(make_repo):
+    """All branch children of an octopus merge are grouped under it as indented entries."""
+    repo = make_repo('octopus_merge')
+    result = bc_show_eligible(repo, 'master', 'stable')
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+
+    lines = result.stdout.splitlines()
+    m_idx = next((i for i, l in enumerate(lines) if 'Merge feature1 and feature2' in l), None)
+    assert m_idx is not None, "octopus merge commit not found in output"
+
+    children = [l for l in lines[m_idx + 1:] if l.startswith(' ')]
+    assert children, "no indented children found under octopus merge"
+    assert any('Feature1 part 1' in l for l in children), \
+        f"Feature1 part 1 not grouped under octopus merge: {children}"
+    assert any('Feature1 part 2' in l for l in children), \
+        f"Feature1 part 2 not grouped under octopus merge: {children}"
+    assert any('Feature2 commit' in l for l in children), \
+        f"Feature2 commit not grouped under octopus merge: {children}"


### PR DESCRIPTION
Introduces a pytest-based test suite under tests/ covering both tools.

Infrastructure

  run_tests.sh — entry point: rebuilds all fixture repos from .sh scripts, then runs pytest
  conftest.py — shared helpers
  Fixture repos are built by shell scripts and exported as git fast-import streams (.fi files, gitignored); re-run the .sh to regenerate

Fixtures

  merge_differing_messages — merge commits whose messages differ from their branch children (the original grouping bug)
  mainline_not_first_parent — a feature branch that did git merge master mid-way, leaving mainline at parents[1] of the sync merge
  bc_cherry_pick_scenarios — real file-content commits (required for non-empty cherry-picks)
  octopus_merge — three-parent merge of two feature branches

bc-show-eligible tests

  * Merge children appear indented under their merge commit, not as standalone entries
  * Grouping is by git parentage, not by message similarity
  * A commit already cherry-picked to the target branch is absent from the output
  * A commit not yet cherry-picked appears as a top-level entry
  * When the mainline parent is not first in the parents list, the merge line is prefixed with --select=HASH
  * All branch children of an octopus merge are indented under it

bc-cherry-pick tests

  * A regular commit is cherry-picked as-is with no children annotation
  * Cherry-picking a merge commit amends the message with (with child HASH) for each branch child
  * --select changes which parent is mainline; the opposite side's commits appear in the children list
  * --no-commit leaves HEAD unchanged and writes the children list to MERGE_MSG
  * --dry-run prints the commands without executing; HEAD unchanged
  * --select with an unknown hash exits non-zero with an error message
  * An octopus merge is cherry-picked cleanly; children from the first branch parent are annotated