### PR TITLE
BCM-35752: GIT-HELPERS: Update manpages for bc-show-eligible and bc-cherry-pick

### DIFF
--- a/man/git-bc-cherry-pick.1.ronn
+++ b/man/git-bc-cherry-pick.1.ronn
@@ -11,45 +11,35 @@ Given an existing commit, apply the changes it introduced, recording a new
 commit in the current branch. This requires your working tree to be clean (no
 modifications from the HEAD commit).
 
-The command applies a standard git-cherry-pick(1) with the given commit. It
-works the same way, except that in case the given commit is a merge, it asks
-interactively what is the branch to consider in the cherry pick. By default it
-does not commit, but only stages the changes, so it allows you to review them.
+For a regular commit, the command behaves exactly like git-cherry-pick(1).
 
-In case the command can't figure out what branch to apply automatically, this
-is the prompt it presents to you:
+For a merge commit, the mainline parent is determined automatically: by git
+convention the first parent (`parents[0]`) is always the branch the merge was
+performed onto, so the changes introduced by the other side are applied. The
+resulting commit message is amended with one `(with child <hash>)` line per
+commit on the branch side, so that git-bc-show-eligible(1) can later detect
+that those commits have already been backported.
 
-```
-This is a merge commit
-Select one option to review the state or the branch to apply:
-    graph)      review the commit graph
-    commits)    review the list of commits
-    diff)       review the diff
-    1|2)        select the branch to be applied (1 or 2)
-    help)       show this message
-    quit)       abort
+If the heuristic picks the wrong mainline — for example when the merge commit
+was created from the feature branch side rather than from master — the command
+prints a suggested retry command with `--select` pointing at the correct
+mainline. git-bc-show-eligible(1) also detects this situation and prefixes the
+line with `--select=<hash>` ready for copy-paste.
 
-Selection (<NUM>/g/c/d/h/q)
-```
-
-Options `graph`, `commits` and `diff` gives an overview of the branches to be
-considered, `1` selects the first branch and `2` the second one. Option `q` is
-to abort the cherry-pick.
-
-If conflicts arise, you will need to resolve them by editing the files and
-adding them with git-add(1) and continue the cherry-pick with git-cherry-pick(1)
-with the `--continue` option. You can use git-status(1) to be guided through
-this process.
+If conflicts arise, resolve them by editing the affected files, staging them
+with git-add(1), and continuing with `git cherry-pick --continue`. Use
+git-status(1) to be guided through the process.
 
 ## OPTIONS
 
   * `-n`, `--no-commit`:
-    Stage changes if the cherry-pick succedes, but do not commit.
+    Stage changes but do not commit. The children list is appended to
+    `MERGE_MSG` so it is available for a manual `git commit`.
 
   * `-s <commit>`, `--select <commit>`:
-    Select this commit as the parent to apply in the cherry-pick. This option
-    is meaningful only when the commit to cherry-pick is a merge and the branch
-    to apply is ambiguous.
+    Treat <commit> as the mainline parent instead of `parents[0]`. Accepts a
+    full hash or any unambiguous prefix. Use this when the auto-detected
+    mainline is wrong.
 
   * `--dry-run`:
     Do not actually execute the git commands, but only print them.
@@ -60,82 +50,51 @@ this process.
 
 ## EXAMPLES
 
-Suppose to have this history:
+Suppose the following history:
 
-```
-     .---B---C---D---
-    /   /       /
----A   /       /
-    \ /       /
-     E-------F
+    master:  A --- X --- M --- P
+                        /
+    feature:       F1--F2
 
----G---H
-```
+    stable:  A --- S
 
-The commits are:
+Commits M and P are on master. F1, F2 are on a feature branch. S is on the
+stable branch you are backporting onto.
 
-  * A is the common ancestor between two branches.
-  * Commits B, C, D are part of the master branch.
-  * Commits E, F are part of a feature branch.
-  * Commits B and D are merge commits between the two branches. They are however
-    different, because D is a normal merge bringing together commits B, C and F,
-    while B has been created with `--ff-only option`, so even if master hasn't
-    changed in the meantime, instead of fast forwarding master to E, a new merge
-    commit has been created.
-  * Commits G, H are commits of a release branch (H is its last commit).
+Cherry-pick the regular commit P:
 
-You want to cherry pick onto the release branch one of the commits in the
-other two branches. The other two branches are not affected. The end result for
-the release branch will be this in all the examples:
+    $ git bc-cherry-pick P
 
-```
----G---H---I
-```
+The command performs a plain cherry-pick, equivalent to `git cherry-pick -x P`.
 
-If you want to cherry-pick the commit F:
+Cherry-pick the merge commit M:
 
-    $ git bc-cherry-pick F
+    $ git bc-cherry-pick M
 
-    The command will simply cherry pick the commit and create I, without user
-    interaction.
+The command detects that M is a merge, identifies X as the mainline
+(`parents[0]`), and cherry-picks the feature side (F1, F2). The resulting
+commit on stable has the original merge message amended with:
 
-If you want to cherry-pick the commit B:
+    (with child <hash of F2>)
+    (with child <hash of F1>)
 
-    $ git bc-cherry-pick B
+If the result looks wrong because the wrong mainline was picked, the command
+prints:
 
-    The command will simply cherry pick the commit and create I, without user
-    interaction. This is possible because she branch to select is unambiguosly
-    the one containing E, since the other one is empty (i.e. there are no
-    commits between A (common ancestor) and B.
+    If the result looks wrong:
+      - conflicts pending:   git cherry-pick --abort
+      - applied cleanly:     git reset --soft <HEAD before>
+    Then retry with:         git bc-cherry-pick --select <branch-parent> <commit>
 
-If you want to cherry-pick the commit D, with the commits introduced in the
-feature branch:
+Cherry-pick a merge commit where the mainline is not `parents[0]`:
 
-    $ git bc-cherry-pick D
+    $ git bc-cherry-pick --select X M
 
-    The command will stop and ask for user interaction, because it doesn't know
-    which branch to apply. The choice is between commits E, F, or B, C. In this
-    case we want E, F. To help us on selecting the branch we can review their
-    contents by selecting `c` in the prompt. The outupt will be this:
-
-    Branch 1:
-    C message 2
-    B message 1
-
-    Branch 2:
-    E message 3
-    F message 4
-
-    In this case we need to input `2` to select the second branch.
-
-If you don't want to use the interactive mode and you already know which parent
-to apply, you can specify it with the `--select` option:
-
-    $ git bc-cherry-pick -s E D
-
-    The command will cherry-pick the the second branch, because E is the first
-    commit of that branch.
+This is needed when the merge commit was created from the feature branch side
+(so `parents[0]` points into the feature, not into master). git-bc-show-eligible(1)
+detects this automatically and displays the line prefixed with `--select=<hash>`
+ready for copy-paste.
 
 ## SEE ALSO
 
-git-cherry-pick(1)
+git-cherry-pick(1), git-bc-show-eligible(1)

--- a/man/git-bc-show-eligible.1.ronn
+++ b/man/git-bc-show-eligible.1.ronn
@@ -1,0 +1,101 @@
+git-bc-show-eligible(1) -- Show commits eligible for cherry-picking
+====================================================================
+
+## SYNOPSIS
+
+`git bc-show-eligible` [<options>] [<branch>] [<target-branch>]
+
+## DESCRIPTION
+
+Lists commits on <branch> that have not yet been cherry-picked onto
+<target-branch>, so they are candidates for backporting with
+git-bc-cherry-pick(1).
+
+A commit is considered already picked if <target-branch> contains a commit
+whose message includes `cherry picked from commit <hash>` (added by
+`git cherry-pick -x`) or `with child <hash>` (added by git-bc-cherry-pick(1)
+when picking a merge commit).
+
+By default only commits authored by the current git user are shown. Use
+`--all` to include commits from all authors.
+
+Merge commits are shown together with their branch-side children, indented
+below the merge line with tree connectors:
+
+    <hash> Merge commit message
+     ├─ <hash> Branch child 1
+     └─ <hash> Branch child 2
+
+When the mainline parent of a merge commit is not `parents[0]` — which
+happens when the merge was performed from the feature branch side rather than
+from master — the line is prefixed with `--select=<hash>` to indicate the
+correct mainline for git-bc-cherry-pick(1):
+
+    --select=<mainline-hash> <hash> Merge commit message
+     └─ <hash> Branch child
+
+This prefix is designed for copy-paste directly into the git-bc-cherry-pick(1)
+invocation.
+
+## OPTIONS
+
+  * `<branch>`:
+    The branch to inspect for eligible commits. Defaults to `origin/master`.
+
+  * `<target-branch>`:
+    The branch to cherry-pick onto. Defaults to `HEAD`.
+
+  * `--since <commit>`:
+    Only show commits reachable from <commit>. Useful for limiting output to
+    a specific range.
+
+  * `--all`:
+    Show commits from all authors, not only the current user.
+
+  * `--add-to-exclude-list <commit>`:
+    Permanently suppress a merge commit (and its children) from the output.
+    The hash is appended to `~/.excludes_show_eligible`. Useful for merge
+    commits that should never be backported.
+
+## EXAMPLES
+
+Suppose the following history:
+
+    master:  A --- X --- M --- P
+                        /
+    feature:       F1--F2
+
+    stable:  A --- S
+
+Show commits on master not yet on stable:
+
+    $ git bc-show-eligible master stable
+    <hash> M
+     ├─ <hash> F2
+     └─ <hash> F1
+    <hash> P
+    <hash> X
+
+After cherry-picking M onto stable with git-bc-cherry-pick(1), its hash
+and those of F1 and F2 are recorded in the stable commit message. Running
+the command again will no longer show M, F1, or F2.
+
+When the mainline parent is not `parents[0]`, the output marks the line for
+the operator:
+
+    --select=<hash of X> <hash> M
+     └─ <hash> F1
+
+Pass the entire prefixed line as arguments to git-bc-cherry-pick(1):
+
+    $ git bc-cherry-pick --select=<hash of X> <hash of M>
+
+## FILES
+
+  * `~/.excludes_show_eligible`:
+    Per-user list of merge commit hashes to suppress from output. One hash
+    per line. Managed with `--add-to-exclude-list`.
+
+## SEE ALSO
+
+git-bc-cherry-pick(1), git-cherry-pick(1)

--- a/man/man1/git-bc-cherry-pick.1
+++ b/man/man1/git-bc-cherry-pick.1
@@ -1,195 +1,88 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-BC\-CHERRY\-PICK" "1" "November 2016" "" ""
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-BC\-CHERRY\-PICK" "1" "April 2026" ""
 .SH "NAME"
 \fBgit\-bc\-cherry\-pick\fR \- Apply the changes introduced by some existing commits
-.
 .SH "SYNOPSIS"
 \fBgit bc\-cherry\-pick\fR [\fIoptions\fR] \fIcommit\fR
-.
 .SH "DESCRIPTION"
 Given an existing commit, apply the changes it introduced, recording a new commit in the current branch\. This requires your working tree to be clean (no modifications from the HEAD commit)\.
-.
 .P
-The command applies a standard git\-cherry\-pick(1) with the given commit\. It works the same way, except that in case the given commit is a merge, it asks interactively what is the branch to consider in the cherry pick\. By default it does not commit, but only stages the changes, so it allows you to review them\.
-.
+For a regular commit, the command behaves exactly like git\-cherry\-pick(1)\.
 .P
-In case the command can\'t figure out what branch to apply automatically, this is the prompt it presents to you:
-.
-.IP "" 4
-.
-.nf
-
-This is a merge commit
-Select one option to review the state or the branch to apply:
-    graph)      review the commit graph
-    commits)    review the list of commits
-    diff)       review the diff
-    1|2)        select the branch to be applied (1 or 2)
-    help)       show this message
-    quit)       abort
-
-Selection (<NUM>/g/c/d/h/q)
-.
-.fi
-.
-.IP "" 0
-.
+For a merge commit, the mainline parent is determined automatically: by git convention the first parent (\fBparents[0]\fR) is always the branch the merge was performed onto, so the changes introduced by the other side are applied\. The resulting commit message is amended with one \fB(with child <hash>)\fR line per commit on the branch side, so that git\-bc\-show\-eligible(1) can later detect that those commits have already been backported\.
 .P
-Options \fBgraph\fR, \fBcommits\fR and \fBdiff\fR gives an overview of the branches to be considered, \fB1\fR selects the first branch and \fB2\fR the second one\. Option \fBq\fR is to abort the cherry\-pick\.
-.
+If the heuristic picks the wrong mainline \(em for example when the merge commit was created from the feature branch side rather than from master \(em the command prints a suggested retry command with \fB\-\-select\fR pointing at the correct mainline\. git\-bc\-show\-eligible(1) also detects this situation and prefixes the line with \fB\-\-select=<hash>\fR ready for copy\-paste\.
 .P
-If conflicts arise, you will need to resolve them by editing the files and adding them with git\-add(1) and continue the cherry\-pick with git\-cherry\-pick(1) with the \fB\-\-continue\fR option\. You can use git\-status(1) to be guided through this process\.
-.
+If conflicts arise, resolve them by editing the affected files, staging them with git\-add(1), and continuing with \fBgit cherry\-pick \-\-continue\fR\. Use git\-status(1) to be guided through the process\.
 .SH "OPTIONS"
-.
 .TP
 \fB\-n\fR, \fB\-\-no\-commit\fR
-Stage changes if the cherry\-pick succedes, but do not commit\.
-.
+Stage changes but do not commit\. The children list is appended to \fBMERGE_MSG\fR so it is available for a manual \fBgit commit\fR\.
 .TP
 \fB\-s <commit>\fR, \fB\-\-select <commit>\fR
-Select this commit as the parent to apply in the cherry\-pick\. This option is meaningful only when the commit to cherry\-pick is a merge and the branch to apply is ambiguous\.
-.
+Treat \fIcommit\fR as the mainline parent instead of \fBparents[0]\fR\. Accepts a full hash or any unambiguous prefix\. Use this when the auto\-detected mainline is wrong\.
 .TP
 \fB\-\-dry\-run\fR
 Do not actually execute the git commands, but only print them\.
-.
 .TP
 \fB<commit>\fR
 The SHA\-1 identifier of the commit to use for the cherry\-pick\. See gitrevisions(7)\. This parameter is mandatory\.
-.
 .SH "EXAMPLES"
-Suppose to have this history:
-.
+Suppose the following history:
 .IP "" 4
-.
 .nf
+master:  A \-\-\- X \-\-\- M \-\-\- P
+                    /
+feature:       F1\-\-F2
 
-     \.\-\-\-B\-\-\-C\-\-\-D\-\-\-
-    /   /       /
-\-\-\-A   /       /
-    \e /       /
-     E\-\-\-\-\-\-\-F
-
-\-\-\-G\-\-\-H
-.
+stable:  A \-\-\- S
 .fi
-.
 .IP "" 0
-.
 .P
-The commits are:
-.
-.IP "\(bu" 4
-A is the common ancestor between two branches\.
-.
-.IP "\(bu" 4
-Commits B, C, D are part of the master branch\.
-.
-.IP "\(bu" 4
-Commits E, F are part of a feature branch\.
-.
-.IP "\(bu" 4
-Commits B and D are merge commits between the two branches\. They are however different, because D is a normal merge bringing together commits B, C and F, while B has been created with \fB\-\-ff\-only option\fR, so even if master hasn\'t changed in the meantime, instead of fast forwarding master to E, a new merge commit has been created\.
-.
-.IP "\(bu" 4
-Commits G, H are commits of a release branch (H is its last commit)\.
-.
-.IP "" 0
-.
+Commits M and P are on master\. F1, F2 are on a feature branch\. S is on the stable branch you are backporting onto\.
 .P
-You want to cherry pick onto the release branch one of the commits in the other two branches\. The other two branches are not affected\. The end result for the release branch will be this in all the examples:
-.
+Cherry\-pick the regular commit P:
 .IP "" 4
-.
 .nf
-
-\-\-\-G\-\-\-H\-\-\-I
-.
+$ git bc\-cherry\-pick P
 .fi
-.
 .IP "" 0
-.
 .P
-If you want to cherry\-pick the commit F:
-.
-.IP "" 4
-.
-.nf
-
-$ git bc\-cherry\-pick F
-
-The command will simply cherry pick the commit and create I, without user
-interaction\.
-.
-.fi
-.
-.IP "" 0
-.
+The command performs a plain cherry\-pick, equivalent to \fBgit cherry\-pick \-x P\fR\.
 .P
-If you want to cherry\-pick the commit B:
-.
+Cherry\-pick the merge commit M:
 .IP "" 4
-.
 .nf
-
-$ git bc\-cherry\-pick B
-
-The command will simply cherry pick the commit and create I, without user
-interaction\. This is possible because she branch to select is unambiguosly
-the one containing E, since the other one is empty (i\.e\. there are no
-commits between A (common ancestor) and B\.
-.
+$ git bc\-cherry\-pick M
 .fi
-.
 .IP "" 0
-.
 .P
-If you want to cherry\-pick the commit D, with the commits introduced in the feature branch:
-.
+The command detects that M is a merge, identifies X as the mainline (\fBparents[0]\fR), and cherry\-picks the feature side (F1, F2)\. The resulting commit on stable has the original merge message amended with:
 .IP "" 4
-.
 .nf
-
-$ git bc\-cherry\-pick D
-
-The command will stop and ask for user interaction, because it doesn\'t know
-which branch to apply\. The choice is between commits E, F, or B, C\. In this
-case we want E, F\. To help us on selecting the branch we can review their
-contents by selecting `c` in the prompt\. The outupt will be this:
-
-Branch 1:
-C message 2
-B message 1
-
-Branch 2:
-E message 3
-F message 4
-
-In this case we need to input `2` to select the second branch\.
-.
+(with child <hash of F2>)
+(with child <hash of F1>)
 .fi
-.
 .IP "" 0
-.
 .P
-If you don\'t want to use the interactive mode and you already know which parent to apply, you can specify it with the \fB\-\-select\fR option:
-.
+If the result looks wrong because the wrong mainline was picked, the command prints:
 .IP "" 4
-.
 .nf
-
-$ git bc\-cherry\-pick \-s E D
-
-The command will cherry\-pick the the second branch, because E is the first
-commit of that branch\.
-.
+If the result looks wrong:
+  \- conflicts pending:   git cherry\-pick \-\-abort
+  \- applied cleanly:     git reset \-\-soft <HEAD before>
+Then retry with:         git bc\-cherry\-pick \-\-select <branch\-parent> <commit>
 .fi
-.
 .IP "" 0
-.
+.P
+Cherry\-pick a merge commit where the mainline is not \fBparents[0]\fR:
+.IP "" 4
+.nf
+$ git bc\-cherry\-pick \-\-select X M
+.fi
+.IP "" 0
+.P
+This is needed when the merge commit was created from the feature branch side (so \fBparents[0]\fR points into the feature, not into master)\. git\-bc\-show\-eligible(1) detects this automatically and displays the line prefixed with \fB\-\-select=<hash>\fR ready for copy\-paste\.
 .SH "SEE ALSO"
-git\-cherry\-pick(1)
+git\-cherry\-pick(1), git\-bc\-show\-eligible(1)

--- a/man/man1/git-bc-show-eligible.1
+++ b/man/man1/git-bc-show-eligible.1
@@ -1,0 +1,94 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-BC\-SHOW\-ELIGIBLE" "1" "April 2026" ""
+.SH "NAME"
+\fBgit\-bc\-show\-eligible\fR \- Show commits eligible for cherry\-picking
+.SH "SYNOPSIS"
+\fBgit bc\-show\-eligible\fR [\fIoptions\fR] [\fIbranch\fR] [\fItarget\-branch\fR]
+.SH "DESCRIPTION"
+Lists commits on \fIbranch\fR that have not yet been cherry\-picked onto \fItarget\-branch\fR, so they are candidates for backporting with git\-bc\-cherry\-pick(1)\.
+.P
+A commit is considered already picked if \fItarget\-branch\fR contains a commit whose message includes \fBcherry picked from commit <hash>\fR (added by \fBgit cherry\-pick \-x\fR) or \fBwith child <hash>\fR (added by git\-bc\-cherry\-pick(1) when picking a merge commit)\.
+.P
+By default only commits authored by the current git user are shown\. Use \fB\-\-all\fR to include commits from all authors\.
+.P
+Merge commits are shown together with their branch\-side children, indented below the merge line with tree connectors:
+.IP "" 4
+.nf
+<hash> Merge commit message
+ ├─ <hash> Branch child 1
+ └─ <hash> Branch child 2
+.fi
+.IP "" 0
+.P
+When the mainline parent of a merge commit is not \fBparents[0]\fR \(em which happens when the merge was performed from the feature branch side rather than from master \(em the line is prefixed with \fB\-\-select=<hash>\fR to indicate the correct mainline for git\-bc\-cherry\-pick(1):
+.IP "" 4
+.nf
+\-\-select=<mainline\-hash> <hash> Merge commit message
+ └─ <hash> Branch child
+.fi
+.IP "" 0
+.P
+This prefix is designed for copy\-paste directly into the git\-bc\-cherry\-pick(1) invocation\.
+.SH "OPTIONS"
+.TP
+\fB<branch>\fR
+The branch to inspect for eligible commits\. Defaults to \fBorigin/master\fR\.
+.TP
+\fB<target\-branch>\fR
+The branch to cherry\-pick onto\. Defaults to \fBHEAD\fR\.
+.TP
+\fB\-\-since <commit>\fR
+Only show commits reachable from \fIcommit\fR\. Useful for limiting output to a specific range\.
+.TP
+\fB\-\-all\fR
+Show commits from all authors, not only the current user\.
+.TP
+\fB\-\-add\-to\-exclude\-list <commit>\fR
+Permanently suppress a merge commit (and its children) from the output\. The hash is appended to \fB~/\.excludes_show_eligible\fR\. Useful for merge commits that should never be backported\.
+.SH "EXAMPLES"
+Suppose the following history:
+.IP "" 4
+.nf
+master:  A \-\-\- X \-\-\- M \-\-\- P
+                    /
+feature:       F1\-\-F2
+
+stable:  A \-\-\- S
+.fi
+.IP "" 0
+.P
+Show commits on master not yet on stable:
+.IP "" 4
+.nf
+$ git bc\-show\-eligible master stable
+<hash> M
+ ├─ <hash> F2
+ └─ <hash> F1
+<hash> P
+<hash> X
+.fi
+.IP "" 0
+.P
+After cherry\-picking M onto stable with git\-bc\-cherry\-pick(1), its hash and those of F1 and F2 are recorded in the stable commit message\. Running the command again will no longer show M, F1, or F2\.
+.P
+When the mainline parent is not \fBparents[0]\fR, the output marks the line for the operator:
+.IP "" 4
+.nf
+\-\-select=<hash of X> <hash> M
+ └─ <hash> F1
+.fi
+.IP "" 0
+.P
+Pass the entire prefixed line as arguments to git\-bc\-cherry\-pick(1):
+.IP "" 4
+.nf
+$ git bc\-cherry\-pick \-\-select=<hash of X> <hash of M>
+.fi
+.IP "" 0
+.SH "FILES"
+.TP
+\fB~/\.excludes_show_eligible\fR
+Per\-user list of merge commit hashes to suppress from output\. One hash per line\. Managed with \fB\-\-add\-to\-exclude\-list\fR\.
+.SH "SEE ALSO"
+git\-bc\-cherry\-pick(1), git\-cherry\-pick(1)


### PR DESCRIPTION
Rewrite git-bc-cherry-pick.1.ronn to reflect the new non-interactive behaviour and flipped --select semantics (now selects the mainline parent, not the branch to apply).

Add git-bc-show-eligible.1.ronn describing the eligibility check, merge grouping, children annotation, and the --select=<hash> copy-paste hint.