### PR TITLE
BCM-35762: GIT-HELPERS: bc-show-eligible deduce source branch automatically instead of defaulting to master

### DIFF
--- a/bin/git-bc-show-eligible
+++ b/bin/git-bc-show-eligible
@@ -13,12 +13,30 @@ import os
 
 EXCLUDES_PATH = os.path.join(os.path.expanduser("~"), '.excludes_show_eligible')
 
+def detect_main_branch(top):
+    """Detect the remote main branch via origin/HEAD symbolic ref.
+
+    Returns the branch name (e.g. 'origin/main') or None if it cannot be determined.
+    Users can populate the ref with: git remote set-head origin --auto
+    """
+    try:
+        ref = subprocess.check_output(
+            ['git', 'symbolic-ref', 'refs/remotes/origin/HEAD'],
+            cwd=top,
+            stderr=subprocess.PIPE,
+        ).decode('utf-8').strip()
+        # ref is e.g. 'refs/remotes/origin/main' → strip the prefix
+        return ref.removeprefix('refs/remotes/')
+    except subprocess.CalledProcessError:
+        return None
+
+
 def find_toplevel():
     try:
         return subprocess.check_output(
             ['git', 'rev-parse', '--show-toplevel'],
             stderr=subprocess.PIPE
-        ).rstrip()
+        ).decode('utf-8').strip()
     except subprocess.CalledProcessError:
         return None
 
@@ -168,7 +186,7 @@ def print_groups(groups, excludes, format_commit):
 def main():
     parser = argparse.ArgumentParser(description='Show commits, eligible for cherry-picking')
     parser.add_argument('branch', metavar='BRANCH', help='Name for the branch to check against',
-                        default='origin/master', nargs='?')
+                        default=None, nargs='?')
     parser.add_argument('target_branch', metavar='TARGET_BRANCH', help='Name for the target branch',
                         default='HEAD', nargs='?')
     parser.add_argument('--since', metavar='COMMIT', help='Start checking since specified commit')
@@ -186,24 +204,33 @@ def main():
     args = parser.parse_args()
     repo = pygit2.Repository(top)
 
+    if args.branch is None:
+        branch = detect_main_branch(top)
+        if not branch:
+            print('No branch provided and could not auto-detect one. Run: git remote set-head origin --auto')
+            sys.exit(1)
+        print(f'Auto-detected main branch: {branch}')
+    else:
+        branch = args.branch
+
     if args.add_to_exclude_list:
         add_exclude_hash(excludes, args.add_to_exclude_list)
 
     try:
-        from_commit = repo.revparse_single(args.branch)
+        from_commit = repo.revparse_single(branch)
     except:
-        print('Invalid branch %s' % args.branch)
+        print(f'Invalid branch {branch}')
         sys.exit(1)
 
     try:
         to_commit = repo.revparse_single(args.target_branch)
     except:
-        print('Invalid target branch %s' % args.target_branch)
+        print(f'Invalid target branch {args.target_branch}')
         sys.exit(1)
 
     base_id = repo.merge_base(from_commit.id, to_commit.id)
     if not base_id:
-        print('%s and %s does not have common ancestor' % (args.branch, args.target_branch))
+        print(f'{branch} and {args.target_branch} does not have common ancestor')
         sys.exit(1)
 
     since_commit = None

--- a/man/git-bc-cherry-pick.1.ronn
+++ b/man/git-bc-cherry-pick.1.ronn
@@ -11,7 +11,8 @@ Given an existing commit, apply the changes it introduced, recording a new
 commit in the current branch. This requires your working tree to be clean (no
 modifications from the HEAD commit).
 
-For a regular commit, the command behaves exactly like git-cherry-pick(1).
+For a regular commit, the command behaves like `git cherry-pick -x`, appending
+a `cherry picked from commit <hash>` line to the commit message.
 
 For a merge commit, the mainline parent is determined automatically: by git
 convention the first parent (`parents[0]`) is always the branch the merge was
@@ -65,7 +66,7 @@ Cherry-pick the regular commit P:
 
     $ git bc-cherry-pick P
 
-The command performs a plain cherry-pick, equivalent to `git cherry-pick -x P`.
+The command performs a plain cherry-pick equivalent to `git cherry-pick -x P`.
 
 Cherry-pick the merge commit M:
 

--- a/man/git-bc-show-eligible.1.ronn
+++ b/man/git-bc-show-eligible.1.ronn
@@ -40,7 +40,8 @@ invocation.
 ## OPTIONS
 
   * `<branch>`:
-    The branch to inspect for eligible commits. Defaults to `origin/master`.
+    The branch to inspect for eligible commits. If omitted, auto-detected from
+    the remote's default branch. If detection fails, a hint is printed.
 
   * `<target-branch>`:
     The branch to cherry-pick onto. Defaults to `HEAD`.

--- a/man/man1/git-bc-cherry-pick.1
+++ b/man/man1/git-bc-cherry-pick.1
@@ -8,7 +8,7 @@
 .SH "DESCRIPTION"
 Given an existing commit, apply the changes it introduced, recording a new commit in the current branch\. This requires your working tree to be clean (no modifications from the HEAD commit)\.
 .P
-For a regular commit, the command behaves exactly like git\-cherry\-pick(1)\.
+For a regular commit, the command behaves like \fBgit cherry\-pick \-x\fR, appending a \fBcherry picked from commit <hash>\fR line to the commit message\.
 .P
 For a merge commit, the mainline parent is determined automatically: by git convention the first parent (\fBparents[0]\fR) is always the branch the merge was performed onto, so the changes introduced by the other side are applied\. The resulting commit message is amended with one \fB(with child <hash>)\fR line per commit on the branch side, so that git\-bc\-show\-eligible(1) can later detect that those commits have already been backported\.
 .P
@@ -49,7 +49,7 @@ $ git bc\-cherry\-pick P
 .fi
 .IP "" 0
 .P
-The command performs a plain cherry\-pick, equivalent to \fBgit cherry\-pick \-x P\fR\.
+The command performs a plain cherry\-pick equivalent to \fBgit cherry\-pick \-x P\fR\.
 .P
 Cherry\-pick the merge commit M:
 .IP "" 4

--- a/man/man1/git-bc-show-eligible.1
+++ b/man/man1/git-bc-show-eligible.1
@@ -33,7 +33,7 @@ This prefix is designed for copy\-paste directly into the git\-bc\-cherry\-pick(
 .SH "OPTIONS"
 .TP
 \fB<branch>\fR
-The branch to inspect for eligible commits\. Defaults to \fBorigin/master\fR\.
+The branch to inspect for eligible commits\. If omitted, auto\-detected from the remote's default branch\. If detection fails, a hint is printed\.
 .TP
 \fB<target\-branch>\fR
 The branch to cherry\-pick onto\. Defaults to \fBHEAD\fR\.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,13 @@ def bc_cherry_pick(repo_dir, commit_ref, *args):
     return result
 
 
+def set_origin_head(repo_dir, branch='master'):
+    """Create refs/remotes/origin/{branch} and set refs/remotes/origin/HEAD to point to it."""
+    commit = resolve_ref(repo_dir, branch)
+    git(repo_dir, 'update-ref', f'refs/remotes/origin/{branch}', commit)
+    git(repo_dir, 'symbolic-ref', 'refs/remotes/origin/HEAD', f'refs/remotes/origin/{branch}')
+
+
 def bc_show_eligible(repo_dir, *args):
     result = subprocess.run(
         [BIN_DIR / 'git-bc-show-eligible', *args],

--- a/tests/test_show_eligible.py
+++ b/tests/test_show_eligible.py
@@ -1,4 +1,4 @@
-from conftest import bc_show_eligible, git_cherry_pick, git_cherry_pick_merge, resolve_ref
+from conftest import bc_show_eligible, git_cherry_pick, git_cherry_pick_merge, resolve_ref, set_origin_head
 
 
 def test_merge_groups_by_parentage(make_repo):
@@ -79,6 +79,24 @@ def test_standalone_commit_visible(make_repo):
     top_level = [l for l in result.stdout.splitlines() if not l.startswith(' ')]
     assert any('XXX-30: Fix nasty bug' in l for l in top_level), \
         "'XXX-30: Fix nasty bug' not found as a top-level entry"
+
+
+def test_autodetect_uses_origin_head(make_repo):
+    """When no BRANCH is given and origin/HEAD is set, it is auto-detected and used."""
+    repo = make_repo('merge_differing_messages')
+    set_origin_head(repo, 'master')
+    result = bc_show_eligible(repo)
+    assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+    assert 'Auto-detected main branch: origin/master' in result.stdout
+
+
+def test_autodetect_fails_without_origin_head(make_repo):
+    """When no BRANCH is given and origin/HEAD is absent, exit 1 with an actionable error."""
+    repo = make_repo('merge_differing_messages')
+    result = bc_show_eligible(repo)
+    assert result.returncode == 1
+    assert 'No branch provided and could not auto-detect one' in result.stdout
+    assert 'git remote set-head origin --auto' in result.stdout
 
 
 def test_octopus_merge_children_grouped(make_repo):


### PR DESCRIPTION
When origin/HEAD is not set, the tool exits with an error and prints the command to fix it, instead of silently defaulting to origin/master.

Add tests for bc-show-eligible branch auto-detection

Add set_origin_head helper to conftest: test repos have no remote, so it injects the minimal refs/remotes/origin/HEAD symbolic ref directly without needing a real remote or clone.

Manpages updated accordingly