### PR TITLE
BCM-35781: GIT-HELPERS: Avoid writing to the project directory during test runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,24 @@ import subprocess
 import pytest
 from pathlib import Path
 
-FIXTURES_DIR = Path(__file__).parent / 'fixtures'
 BIN_DIR = Path(__file__).parent.parent / 'bin'
+
+
+def pytest_addoption(parser):
+    parser.addoption('--work-dir', default=None, help='Root temp directory for fixtures and test repos')
+
+
+@pytest.fixture(scope='session')
+def work_dir(request):
+    d = request.config.getoption('--work-dir')
+    if d is None:
+        pytest.exit(
+            'Missing --work-dir. Run the suite via tests/run_tests.sh, '
+            'which prepares fixtures and passes --work-dir automatically.',
+            returncode=1,
+        )
+    return Path(d)
+
 
 
 def cmd_info(result):
@@ -31,16 +47,25 @@ def resolve_ref(repo_dir, ref):
     return git(repo_dir, 'rev-parse', ref).stdout.strip()
 
 
+# Multiple tests may use the same fixture name; a counter ensures each gets
+# its own subdirectory under work_dir/tests/ without collisions.
+_repo_counter = 0
+
+
 @pytest.fixture
-def make_repo(tmp_path):
+def make_repo(work_dir):
     """Return a factory that creates a git repo from a .fi fixture file."""
+    global _repo_counter
+    _repo_counter += 1
+    idx = _repo_counter
+
     def _make(fixture_name):
-        repo_dir = tmp_path / fixture_name
-        repo_dir.mkdir()
+        repo_dir = work_dir / 'tests' / f'{idx}_{fixture_name}'
+        repo_dir.mkdir(parents=True)
         git(repo_dir, 'init')
         git(repo_dir, 'config', 'user.email', 'test@test')
         git(repo_dir, 'config', 'user.name', 'Test')
-        fi_path = FIXTURES_DIR / f'{fixture_name}.fi'
+        fi_path = work_dir / 'fixtures' / f'{fixture_name}.fi'
         with fi_path.open('rb') as f:
             subprocess.run(
                 ['git', 'fast-import', '--quiet'],

--- a/tests/fixtures/bc_cherry_pick_scenarios.sh
+++ b/tests/fixtures/bc_cherry_pick_scenarios.sh
@@ -16,8 +16,10 @@
 
 set -e
 
-REPO=$(mktemp -d)
-trap "rm -rf $REPO" EXIT
+WORK_DIR="${1:?Usage: $0 <work-dir>}"
+FIXTURES_OUT="$WORK_DIR/fixtures"
+
+REPO=$(mktemp -d "$WORK_DIR/repo.XXXXXX")
 
 git -C $REPO init -q
 git -C $REPO config user.email test@test
@@ -58,5 +60,5 @@ echo "patch" > $REPO/patch.txt
 git -C $REPO add patch.txt
 git -C $REPO commit -m "XXX-3: Patch" -q
 
-git -C $REPO fast-export --all > "$(dirname "$0")/bc_cherry_pick_scenarios.fi"
+git -C $REPO fast-export --all > "$FIXTURES_OUT/bc_cherry_pick_scenarios.fi"
 echo "Written bc_cherry_pick_scenarios.fi"

--- a/tests/fixtures/mainline_not_first_parent.sh
+++ b/tests/fixtures/mainline_not_first_parent.sh
@@ -17,8 +17,10 @@
 
 set -e
 
-REPO=$(mktemp -d)
-trap "rm -rf $REPO" EXIT
+WORK_DIR="${1:?Usage: $0 <work-dir>}"
+FIXTURES_OUT="$WORK_DIR/fixtures"
+
+REPO=$(mktemp -d "$WORK_DIR/repo.XXXXXX")
 
 git -C $REPO init -q
 git -C $REPO config user.email test@test
@@ -50,5 +52,5 @@ git -C $REPO commit --allow-empty -m "XXX-2: Feature part 2" -q
 git -C $REPO checkout master -q
 git -C $REPO merge --no-ff feature -m "XXX-2: Feature done" -q
 
-git -C $REPO fast-export --all > "$(dirname "$0")/mainline_not_first_parent.fi"
+git -C $REPO fast-export --all > "$FIXTURES_OUT/mainline_not_first_parent.fi"
 echo "Written mainline_not_first_parent.fi"

--- a/tests/fixtures/merge_differing_messages.sh
+++ b/tests/fixtures/merge_differing_messages.sh
@@ -19,8 +19,10 @@
 
 set -e
 
-REPO=$(mktemp -d)
-trap "rm -rf $REPO" EXIT
+WORK_DIR="${1:?Usage: $0 <work-dir>}"
+FIXTURES_OUT="$WORK_DIR/fixtures"
+
+REPO=$(mktemp -d "$WORK_DIR/repo.XXXXXX")
 
 git -C $REPO init -q
 git -C $REPO config user.email test@test
@@ -66,5 +68,5 @@ git -C $REPO commit --allow-empty -m "XXX-40: New API v3" -q
 git -C $REPO checkout master -q
 git -C $REPO merge --no-ff feature3 -m "XXX-40: New API v3" -q
 
-git -C $REPO fast-export --all > "$(dirname "$0")/merge_differing_messages.fi"
+git -C $REPO fast-export --all > "$FIXTURES_OUT/merge_differing_messages.fi"
 echo "Written merge_differing_messages.fi"

--- a/tests/fixtures/octopus_merge.sh
+++ b/tests/fixtures/octopus_merge.sh
@@ -16,8 +16,10 @@
 
 set -e
 
-REPO=$(mktemp -d)
-trap "rm -rf $REPO" EXIT
+WORK_DIR="${1:?Usage: $0 <work-dir>}"
+FIXTURES_OUT="$WORK_DIR/fixtures"
+
+REPO=$(mktemp -d "$WORK_DIR/repo.XXXXXX")
 
 git -C $REPO init -q
 git -C $REPO config user.email test@test
@@ -59,5 +61,5 @@ git -C $REPO commit -m "XXX-3: Feature2 commit" -q
 git -C $REPO checkout master -q
 git -C $REPO merge --no-ff feature1 feature2 -m "XXX-2/3: Merge feature1 and feature2" -q
 
-git -C $REPO fast-export --all > "$(dirname "$0")/octopus_merge.fi"
+git -C $REPO fast-export --all > "$FIXTURES_OUT/octopus_merge.fi"
 echo "Written octopus_merge.fi"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-# Build all fixture repos and run the test suite.
+# Build all fixture repos into a temp directory and run the test suite.
 # Usage: tests/run_tests.sh [pytest options...]
 set -e
 cd "$(dirname "$0")"
 
+WORK_DIR=$(mktemp -d)
+trap "rm -rf $WORK_DIR" EXIT
+mkdir "$WORK_DIR/fixtures"
+
 for script in fixtures/*.sh; do
     echo "Building fixture: $script"
-    bash "$script"
+    bash "$script" "$WORK_DIR"
 done
 
-exec python3 -m pytest . "$@"
+PYTHONDONTWRITEBYTECODE=1 exec python3 -m pytest . --work-dir="$WORK_DIR" -o "cache_dir=$WORK_DIR/.pytest_cache" "$@"


### PR DESCRIPTION
- All temp files (fixture repos, .fi files, test repos, pytest cache) live under one WORK_DIR
- Single trap in run_tests.sh handles all cleanup
- Project directory is never written to during a test run
- Clear error message if someone runs pytest directly without the wrapper