### PR TITLE
BCM-35807: GIT-HELPERS: bump helpers versions to avoid node20 warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
bump actions/checkout and actions/setup-python to v6 (Node.js 24)